### PR TITLE
feat: adiciona leitura de versão e separador de sessões na sidebar

### DIFF
--- a/lib/components/navigation/side_bar_component.dart
+++ b/lib/components/navigation/side_bar_component.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:rick_morty_app/pages/episodes_page.dart';
 import 'package:rick_morty_app/pages/favorites_page.dart';
 import 'package:rick_morty_app/pages/home_page.dart';
@@ -104,12 +105,18 @@ class SideBarComponent extends StatelessWidget {
 
               Padding(
                 padding: const EdgeInsets.all(16),
-                child: Text(
-                  'v1.0',
-                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: AppColors.white.withValues(alpha: 0.6),
-                      ),
-                  textAlign: TextAlign.right,
+                child: FutureBuilder<PackageInfo>(
+                  future: PackageInfo.fromPlatform(),
+                  builder: (context, snapshot) {
+                    final version = snapshot.hasData ? snapshot.data!.version : '...';
+                    return Text(
+                      'v$version',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: AppColors.white.withValues(alpha: 0.6),
+                          ),
+                      textAlign: TextAlign.right,
+                    );
+                  },
                 ),
               ),
             ],

--- a/lib/components/navigation/side_bar_component.dart
+++ b/lib/components/navigation/side_bar_component.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:package_info_plus/package_info_plus.dart';
+import 'package:rick_morty_app/components/organization/section_label.dart';
 import 'package:rick_morty_app/pages/episodes_page.dart';
 import 'package:rick_morty_app/pages/favorites_page.dart';
 import 'package:rick_morty_app/pages/home_page.dart';
@@ -70,6 +71,9 @@ class SideBarComponent extends StatelessWidget {
                 child: ListView(
                   padding: EdgeInsets.zero,
                   children: [
+
+                    const SectionLabel('Pages'),
+                    
                     ListTile(
                       leading: const Icon(Icons.people_alt_outlined),
                       title: const Text('Characters'),
@@ -91,6 +95,9 @@ class SideBarComponent extends StatelessWidget {
                       selected: _isRoute(context, EpisodesPage.routeId),
                       onTap: () => _goToNamed(context, EpisodesPage.routeId),
                     ),
+
+                    const SectionLabel('Utilities'),
+                    
                     ListTile(
                       leading: const Icon(Icons.favorite_border),
                       iconColor: AppColors.white,

--- a/lib/components/organization/section_label.dart
+++ b/lib/components/organization/section_label.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:rick_morty_app/theme/app_colors.dart';
+
+class SectionLabel extends StatelessWidget {
+  const SectionLabel(this.text, {super.key});
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 14, 16, 6),
+      child: Text(
+        text.toUpperCase(),
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: AppColors.white.withValues(alpha: 0.6),
+              fontWeight: FontWeight.w700,
+              letterSpacing: 0.8,
+            ),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -248,6 +248,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.16.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.1"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: transitive
     description:
@@ -477,6 +493,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: "329edf97fdd893e0f1e3b9e88d6a0e627128cc17cc316a8d67fda8f1451178ba"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.13.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   google_fonts: ^6.3.0
   dio: ^4.0.6
   shared_preferences: ^2.2.3
+  package_info_plus: ^8.3.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Resumo:
- Adiciona versão do pubspec na sidebar (v'...').
- Adiciona widget separador de sessões com text e aplica na sidebar.

Mudanças:
- Sidebar: exibe função presente no pubspec e contém sessões 'Pages' e 'Utilities'.

Como testar:
- Abrir sidebar e verificar se a versão é a mesma do pubspec.