### PR TITLE
feat: Location Details - lista completa de residentes + chips clicáveis + scroll dinâmico

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,16 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR
 ## [Unreleased]
 
 ### Added
-- Location Details: lista de residentes rolável exibindo todos os residentes, sem expandir demais o card.
+- **Location Details**:
+  - Lista de residentes rolável exibindo todos os residentes, sem expandir demais o card.
+  - Chips de residentes clicáveis que abrem a tela do personagem.
 
 ### Changed
-- Location Details: carregamento dos residentes passou a usar busca em lote (via `getCharactersByIds`) para reduzir chamadas à API.
+- **Location Details**:
+  - Carregamento dos residentes passou a usar busca em lote (via `getCharactersByIds`) para reduzir chamadas à API.
+  - Card simplificado para receber residentCharacters e onResidentTap, removendo o uso de residentNames.
+
+- Página de Detalhes de Location: mensagem de erro padronizada para inglês ("An error occurred.").
 
 ## [v1.0.0] - 2025-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR
 
 ## [Unreleased]
 
+### Added
+- Location Details: lista de residentes rolável exibindo todos os residentes, sem expandir demais o card.
+
+### Changed
+- Location Details: carregamento dos residentes passou a usar busca em lote (via `getCharactersByIds`) para reduzir chamadas à API.
+
 ## [v1.0.0] - 2025-08-30
 
 ### Added

--- a/lib/components/detailed_cards/detailed_location_card.dart
+++ b/lib/components/detailed_cards/detailed_location_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:rick_morty_app/models/location.dart';
+import 'package:rick_morty_app/models/character.dart';
 import 'package:rick_morty_app/theme/app_colors.dart';
 import 'package:rick_morty_app/theme/app_typography.dart';
 
@@ -7,11 +8,13 @@ class LocationDetailsCard extends StatelessWidget {
   const LocationDetailsCard({
     super.key,
     required this.location,
-    this.residentNames,
+    required this.residentCharacters,   
+    required this.onResidentTap,        
   });
 
   final LocationRM location;
-  final List<String>? residentNames;
+  final List<Character> residentCharacters;
+  final ValueChanged<int> onResidentTap; // recebe o id do personagem
 
   @override
   Widget build(BuildContext context) {
@@ -39,7 +42,6 @@ class LocationDetailsCard extends StatelessWidget {
             ),
             const SizedBox(height: 15),
 
-            // Type
             Text('Type:', style: AppTypography.attribute(context)),
             const SizedBox(height: 4),
             Text(
@@ -50,7 +52,6 @@ class LocationDetailsCard extends StatelessWidget {
             ),
             const SizedBox(height: 15),
 
-            // Dimension
             Text('Dimension:', style: AppTypography.attribute(context)),
             const SizedBox(height: 4),
             Text(
@@ -61,7 +62,6 @@ class LocationDetailsCard extends StatelessWidget {
             ),
             const SizedBox(height: 15),
 
-            // Residents (count)
             Text('Residents:', style: AppTypography.attribute(context)),
             const SizedBox(height: 4),
             Text(
@@ -70,8 +70,8 @@ class LocationDetailsCard extends StatelessWidget {
             ),
             const SizedBox(height: 15),
 
-            if (residentNames != null) ...[
-              Text('Residents:', style: AppTypography.attribute(context)),
+            if (residentCharacters.isNotEmpty) ...[
+              Text('Residents (${residentCharacters.length}):', style: AppTypography.attribute(context)),
               const SizedBox(height: 8),
 
               ConstrainedBox(
@@ -82,21 +82,26 @@ class LocationDetailsCard extends StatelessWidget {
                     primary: false, // importante p/ NÃO ocupar altura toda
                     child: Wrap(
                       spacing: 8, runSpacing: 8,
-                      children: residentNames!.map((n) => Container(
-                        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-                        decoration: BoxDecoration(
-                          color: AppColors.primaryColorDark.withValues(alpha: 0.2),
+                      children: residentCharacters.map((c) {
+                        return InkWell(
                           borderRadius: const BorderRadius.all(Radius.circular(16)),
-                        ),
-                        child: Text(n, style: AppTypography.answer(context)),
-                      )).toList(),
+                          onTap: () => onResidentTap(c.id),
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                            decoration: BoxDecoration(
+                              color: AppColors.primaryColorDark.withValues(alpha: 0.2),
+                              borderRadius: const BorderRadius.all(Radius.circular(16)),
+                            ),
+                            child: Text(c.name, style: AppTypography.answer(context)),
+                          ),
+                        );
+                      }).toList(),
                     ),
                   ),
                 ),
               ),
             ],
 
-            // distância final igual ao card de character
             const SizedBox(height: 23),
           ],
         ),

--- a/lib/components/detailed_cards/detailed_location_card.dart
+++ b/lib/components/detailed_cards/detailed_location_card.dart
@@ -27,7 +27,6 @@ class LocationDetailsCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // título (mesma tipografia do CharacterDetailsCard)
             Text(
               location.name,
               maxLines: 2,
@@ -71,31 +70,30 @@ class LocationDetailsCard extends StatelessWidget {
             ),
             const SizedBox(height: 15),
 
-            // Lista de alguns residentes (chips), se fornecida
             if (residentNames != null) ...[
-              Text('Some residents:', style: AppTypography.attribute(context)),
+              Text('Residents:', style: AppTypography.attribute(context)),
               const SizedBox(height: 8),
-              if (residentNames!.isEmpty)
-                Text('—', style: AppTypography.answer(context))
-              else
-                Wrap(
-                  spacing: 8,
-                  runSpacing: 8,
-                  children: residentNames!
-                      .map(
-                        (n) => Container(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 10, vertical: 6,
-                          ),
-                          decoration: BoxDecoration(
-                            color: AppColors.primaryColorDark.withValues(alpha: 0.2),
-                            borderRadius: const BorderRadius.all(Radius.circular(16)),
-                          ),
-                          child: Text(n, style: AppTypography.answer(context)),
+
+              ConstrainedBox(
+                constraints: const BoxConstraints(maxHeight: 170),
+                child: Scrollbar(
+                  thumbVisibility: true,
+                  child: SingleChildScrollView(
+                    primary: false, // importante p/ NÃO ocupar altura toda
+                    child: Wrap(
+                      spacing: 8, runSpacing: 8,
+                      children: residentNames!.map((n) => Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                        decoration: BoxDecoration(
+                          color: AppColors.primaryColorDark.withValues(alpha: 0.2),
+                          borderRadius: const BorderRadius.all(Radius.circular(16)),
                         ),
-                      )
-                      .toList(),
+                        child: Text(n, style: AppTypography.answer(context)),
+                      )).toList(),
+                    ),
+                  ),
                 ),
+              ),
             ],
 
             // distância final igual ao card de character

--- a/lib/data/repository.dart
+++ b/lib/data/repository.dart
@@ -119,6 +119,7 @@ abstract class Repository {
     return Episode.fromJson(res.data);
   }
 
+  // personagens por uma lista de IDs
   static Future<List<Character>> getCharactersByIds(List<int> ids) async {
     if (ids.isEmpty) return <Character>[];
     final path = ids.length == 1 ? '/character/${ids.first}' : '/character/[${ids.join(',')}]';


### PR DESCRIPTION
Resumo:
- Exibe todos os residentes do local (sem limitar), deixando o card com altura dinâmica e scroll interno.
- Chips de residentes clicáveis que abrem a tela do personagem.

Mudanças:
 - LocationDetailsPage: carrega todos os residentes do local em uma chamada em lote e ordena por nome.
- LocationDetailsCard: simplificado para receber lista de Characters e um callback onResidentTap (chips clicáveis).
- Repository: reuso do método de batch fetch de personagens (getCharactersByIds).
- UI: bloco de residentes com altura adaptativa (até 170px) e scrollbar visível quando necessário.

Como testar:
- Abrir uma Location com poucos residentes → a seção ocupa só o necessário (sem espaço sobrando).
- Abrir uma Location com muitos residentes → a seção mostra todos e habilita scroll interno.
- Tocar em qualquer chip de residente → deve navegar para Character Details do respectivo personagem.