### PR TITLE
feat: episode details com chips de personagens + links clicáveis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR
 - **Character Details**:
   - Links clicáveis para Last known location e Origin que abrem a tela de Location.
   - Link clicável em First seen in que abre a tela de Episode.
+- **Episode Details**:
+  - Exibição de todos os personagens como chips roláveis.
+  - Chips clicáveis que abrem a tela de Character.
 - **Utils**:
   - Helper `id_from_url.dart` para extrair o ID a partir de URLs.
 

--- a/lib/components/detailed_cards/detailed_episode_card.dart
+++ b/lib/components/detailed_cards/detailed_episode_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:rick_morty_app/models/character.dart';
 import 'package:rick_morty_app/models/episode.dart';
 import 'package:rick_morty_app/theme/app_colors.dart';
 import 'package:rick_morty_app/theme/app_typography.dart';
@@ -7,9 +8,13 @@ class DetailedEpisodeCard extends StatelessWidget {
   const DetailedEpisodeCard({
     super.key,
     required this.episode,
+    this.characters,  
+    this.onCharacterTap,
   });
 
   final Episode episode;
+  final List<Character>? characters;       
+  final ValueChanged<int>? onCharacterTap;
 
   @override
   Widget build(BuildContext context) {
@@ -56,14 +61,41 @@ class DetailedEpisodeCard extends StatelessWidget {
               overflow: TextOverflow.ellipsis,
               style: AppTypography.answer(context),
             ),
-            const SizedBox(height: 15),
 
-            Text('Characters:', style: AppTypography.attribute(context)),
-            const SizedBox(height: 4),
-            Text(
-              '${episode.characters.length} appearance(s)',
-              style: AppTypography.answer(context),
-            ),
+            if (characters != null && characters!.isNotEmpty) ...[
+              const SizedBox(height: 15),
+
+              Text('Characters (${episode.characters.length}):', style: AppTypography.attribute(context)),
+              const SizedBox(height: 8),
+
+              ConstrainedBox(
+                constraints: const BoxConstraints(maxHeight: 170),
+                child: Scrollbar(
+                  thumbVisibility: true,
+                  child: SingleChildScrollView(
+                    primary: false,
+                    child: Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
+                      children: characters!.map((c) {
+                        return InkWell(
+                          borderRadius: const BorderRadius.all(Radius.circular(16)),
+                          onTap: onCharacterTap == null ? null : () => onCharacterTap!(c.id),
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                            decoration: BoxDecoration(
+                              color: AppColors.primaryColorDark.withValues(alpha: 0.2),
+                              borderRadius: const BorderRadius.all(Radius.circular(16)),
+                            ),
+                            child: Text(c.name, style: AppTypography.answer(context)),
+                          ),
+                        );
+                      }).toList(),
+                    ),
+                  ),
+                ),
+              ),
+            ],
 
             const SizedBox(height: 23),
           ],

--- a/lib/pages/episode_details_page.dart
+++ b/lib/pages/episode_details_page.dart
@@ -3,12 +3,36 @@ import 'package:rick_morty_app/components/app_bar/app_bar_component.dart';
 import 'package:rick_morty_app/components/detailed_cards/detailed_episode_card.dart';
 import 'package:rick_morty_app/data/repository.dart';
 import 'package:rick_morty_app/models/episode.dart';
+import 'package:rick_morty_app/models/character.dart';
+import 'package:rick_morty_app/pages/details_page.dart';
 import 'package:rick_morty_app/theme/app_colors.dart';
+import 'package:rick_morty_app/utils/id_from_url.dart';
 
-class EpisodeDetailsPage extends StatelessWidget {
+class EpisodeDetailsPage extends StatefulWidget {
   static const routeId = '/episode_details';
   const EpisodeDetailsPage({super.key, required this.episodeId});
   final int episodeId;
+
+  @override
+  State<EpisodeDetailsPage> createState() => _EpisodeDetailsPageState();
+}
+
+class _EpisodeDetailsPageState extends State<EpisodeDetailsPage> {
+  late Future<Episode> _episodeFuture;
+  late Future<List<Character>> _charsFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _episodeFuture = Repository.getEpisodeDetails(widget.episodeId);
+    _charsFuture = _episodeFuture.then((ep) async {
+      final ids = ep.characters.map(idFromUrl).whereType<int>().toSet().toList();
+      if (ids.isEmpty) return <Character>[];
+      final chars = await Repository.getCharactersByIds(ids);
+      chars.sort((a, b) => a.name.compareTo(b.name));
+      return chars;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -16,7 +40,7 @@ class EpisodeDetailsPage extends StatelessWidget {
       appBar: appBarComponent(context, isSecondPage: true),
       backgroundColor: AppColors.backgroundColor,
       body: FutureBuilder<Episode>(
-        future: Repository.getEpisodeDetails(episodeId),
+        future: _episodeFuture,
         builder: (context, snapshot) {
           if (snapshot.connectionState == ConnectionState.waiting) {
             return const Center(child: CircularProgressIndicator());
@@ -26,12 +50,33 @@ class EpisodeDetailsPage extends StatelessWidget {
               child: Text('An error occurred.', style: TextStyle(color: AppColors.white)),
             );
           }
+
           final ep = snapshot.data!;
-          return ListView(
-            padding: EdgeInsets.zero,
-            children: [
-              DetailedEpisodeCard(episode: ep),
-            ],
+          return FutureBuilder<List<Character>>(
+            future: _charsFuture,
+            builder: (context, cSnap) {
+              if (cSnap.connectionState == ConnectionState.waiting && !cSnap.hasData) {
+                return const Center(child: CircularProgressIndicator());
+              }
+              final chars = cSnap.data; // pode ser nulo enquanto carrega
+              return ListView(
+                padding: EdgeInsets.zero,
+                children: [
+                  DetailedEpisodeCard(
+                    episode: ep,
+                    characters: chars,
+                    onCharacterTap: (id) {
+                      Navigator.of(context).push(
+                        MaterialPageRoute(
+                          settings: const RouteSettings(name: DetailsPage.routeId),
+                          builder: (_) => DetailsPage(characterId: id),
+                        ),
+                      );
+                    },
+                  ),
+                ],
+              );
+            },
           );
         },
       ),


### PR DESCRIPTION
Resumo:
- Mostra todos os personagens do episódio como chips roláveis.
- Chips são clicáveis e abrem a tela de Character Details.
- EpisodeDetailsPage convertida para Stateful (futuros criados no initState).

Mudanças:
- UI: DetailedEpisodeCard agora aceita characters e onCharacterTap, renderizando chips com Wrap + Scroll (altura dinâmica até o limite, igual Location).
- Página: EpisodeDetailsPage extrai IDs das URLs do episódio e busca personagens via Repository.getCharactersByIds; ordena por nome e injeta no card; navegação para DetailsPage(characterId).

Como testar:
- Abrir Episodes → selecionar um episódio com personagens.
- Conferir que os chips aparecem (roláveis quando vários).
- Tocar em um chip → deve abrir Character Details do personagem.