### PR TITLE
refactor: padroniza chips clicáveis dos episódios

### DIFF
--- a/lib/components/detailed_cards/detailed_episode_card.dart
+++ b/lib/components/detailed_cards/detailed_episode_card.dart
@@ -8,12 +8,12 @@ class DetailedEpisodeCard extends StatelessWidget {
   const DetailedEpisodeCard({
     super.key,
     required this.episode,
-    this.characters,  
-    this.onCharacterTap,
+    required this.characters,  
+    required this.onCharacterTap,
   });
 
   final Episode episode;
-  final List<Character>? characters;       
+  final List<Character> characters;       
   final ValueChanged<int>? onCharacterTap;
 
   @override
@@ -62,10 +62,10 @@ class DetailedEpisodeCard extends StatelessWidget {
               style: AppTypography.answer(context),
             ),
 
-            if (characters != null && characters!.isNotEmpty) ...[
+            if (characters.isNotEmpty) ...[
               const SizedBox(height: 15),
 
-              Text('Characters (${episode.characters.length}):', style: AppTypography.attribute(context)),
+              Text('Characters (${characters.length}):', style: AppTypography.attribute(context)),
               const SizedBox(height: 8),
 
               ConstrainedBox(
@@ -77,7 +77,7 @@ class DetailedEpisodeCard extends StatelessWidget {
                     child: Wrap(
                       spacing: 8,
                       runSpacing: 8,
-                      children: characters!.map((c) {
+                      children: characters.map((c) {
                         return InkWell(
                           borderRadius: const BorderRadius.all(Radius.circular(16)),
                           onTap: onCharacterTap == null ? null : () => onCharacterTap!(c.id),

--- a/lib/pages/episode_details_page.dart
+++ b/lib/pages/episode_details_page.dart
@@ -25,13 +25,19 @@ class _EpisodeDetailsPageState extends State<EpisodeDetailsPage> {
   void initState() {
     super.initState();
     _episodeFuture = Repository.getEpisodeDetails(widget.episodeId);
-    _charsFuture = _episodeFuture.then((ep) async {
-      final ids = ep.characters.map(idFromUrl).whereType<int>().toSet().toList();
-      if (ids.isEmpty) return <Character>[];
-      final chars = await Repository.getCharactersByIds(ids);
-      chars.sort((a, b) => a.name.compareTo(b.name));
-      return chars;
-    });
+    _charsFuture = _loadChars();
+  }
+
+  Future<List<Character>> _loadChars() async {
+    final loc = await _episodeFuture;
+    final ids = loc.characters
+        .map(idFromUrl).whereType<int>().toSet().toList();
+
+    if (ids.isEmpty) return const <Character>[];
+
+    final characters = await Repository.getCharactersByIds(ids);
+    characters.sort((a, b) => a.name.compareTo(b.name));
+    return characters;
   }
 
   @override
@@ -64,7 +70,7 @@ class _EpisodeDetailsPageState extends State<EpisodeDetailsPage> {
                 children: [
                   DetailedEpisodeCard(
                     episode: ep,
-                    characters: chars,
+                    characters: chars ?? const <Character>[],
                     onCharacterTap: (id) {
                       Navigator.of(context).push(
                         MaterialPageRoute(


### PR DESCRIPTION
Resumo:
- Padroniza DetailedEpisodeCard para manter consistência com outros cards.

Como testar:
- Abrir qualquer episódio na EpisodeDetailsPage → verificar se funciona.