### PR TITLE
feat: botão Home na AppBar das telas de detalhe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR
 
 ## [Unreleased]
 
+### Added
+- AppBar (telas de detalhe): botão Home ao lado do Voltar para retornar diretamente à página inicial.
+
 ## [v1.1.0] - 2025-09-03
 
 ### Added

--- a/lib/components/app_bar/app_bar_component.dart
+++ b/lib/components/app_bar/app_bar_component.dart
@@ -10,26 +10,44 @@ PreferredSizeWidget appBarComponent(BuildContext context, {bool isSecondPage = f
     backgroundColor: AppColors.appBarColor,
     systemOverlayStyle: SystemUiOverlayStyle.dark,
 
+    // espaço extra só nas páginas de detalhe (voltar + home)
+    leadingWidth: isSecondPage ? 96 : null,
+
     leading: Builder(
       builder: (ctx) => Align(
         alignment: Alignment.topCenter,
         child: Padding(
           padding: const EdgeInsets.only(top: 6),
-          child: GestureDetector(
-            onTap: () {
-              if (isSecondPage) {
-                final currentRoute = ModalRoute.of(ctx)?.settings.name;
-                if (currentRoute == HomePage.routeId) return;
-                Navigator.pop(ctx);
-              } else {
-                Scaffold.of(ctx).openDrawer();
-              }
-            },
-            child: Icon(
-              isSecondPage ? Icons.arrow_back : Icons.menu,
-              color: const Color(0xFFE6E1E5),
-            ),
-          ),
+          child: isSecondPage
+              ? Row(
+                  children: [
+                    const SizedBox(width: 14),
+                    GestureDetector(
+                      onTap: () {
+                        final currentRoute = ModalRoute.of(ctx)?.settings.name;
+                        if (currentRoute == HomePage.routeId) return;
+                        Navigator.pop(ctx);
+                      },
+                      child: const Icon(Icons.arrow_back, color: Color(0xFFE6E1E5)),
+                    ),
+
+                    const SizedBox(width: 10),
+                    GestureDetector(
+                      onTap: () {
+                        Navigator.of(ctx).pushNamedAndRemoveUntil(
+                          HomePage.routeId,
+                          (route) => false,
+                        );
+                      },
+                      child: const Icon(Icons.home_outlined, color: Color(0xFFE6E1E5)),
+                    ),
+                  ],
+                )
+
+              : GestureDetector(
+                  onTap: () => Scaffold.of(ctx).openDrawer(),
+                  child: const Icon(Icons.menu, color: Color(0xFFE6E1E5)),
+                ),
         ),
       ),
     ),
@@ -39,11 +57,7 @@ PreferredSizeWidget appBarComponent(BuildContext context, {bool isSecondPage = f
         alignment: Alignment.topCenter,
         child: Padding(
           padding: const EdgeInsets.only(top: 6, right: 16),
-          child: Icon(
-            Icons.account_circle,
-            color: Color(0xFFCAC4D0),
-            size: 26,
-          ),
+          child: const Icon(Icons.account_circle, color: Color(0xFFCAC4D0), size: 26),
         ),
       ),
     ],
@@ -57,12 +71,12 @@ PreferredSizeWidget appBarComponent(BuildContext context, {bool isSecondPage = f
             child: Text(
               "RICK AND MORTY API",
               style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                color: AppColors.white,
-                fontWeight: FontWeight.w400,
-                fontSize: 14.5,
-                height: 1.0,                 
-                letterSpacing: 14.5 * 0.165, 
-              ),
+                    color: AppColors.white,
+                    fontWeight: FontWeight.w400,
+                    fontSize: 14.5,
+                    height: 1.0,
+                    letterSpacing: 14.5 * 0.165,
+                  ),
             ),
           ),
         ],


### PR DESCRIPTION
Resumo:
- Adiciona um botão Home ao lado do Voltar na AppBar apenas das telas de detalhe (Characters, Locations, Episodes).

Mudanças: 
- Quando isSecondPage: true, o leading mostra Row(Voltar + Home) e ajusta leadingWidth para comportar os dois ícones.
- Ação do Home: Navigator.pushNamedAndRemoveUntil(HomePage.routeId, (route) => false), limpando a pilha e indo direto para a Home.

Como testar:
1. Abrir um personagem, local ou episódio a partir da lista.
2. Verificar que, no topo esquerdo, aparecem Voltar e Home lado a lado.
3. Tocar em Home → deve voltar direto à Home, sem telas intermediárias.
