### PR TITLE
feat: rótulo “Drag to enlarge/reduce” no Character Details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR
 ### Added
 - AppBar (telas de detalhe): botão Home ao lado do Voltar para retornar diretamente à página inicial.
 
+- Character Details: rótulo “Drag to enlarge/reduce” ao lado do ícone de expandir na imagem, orientando o gesto de arrastar para ampliar a foto.
+
 ## [v1.1.0] - 2025-09-03
 
 ### Added

--- a/lib/components/detailed_cards/detailed_character_card.dart
+++ b/lib/components/detailed_cards/detailed_character_card.dart
@@ -84,21 +84,33 @@ class CharacterDetailsCard extends StatelessWidget {
                         right: 8,
                         bottom: 8,
                         child: Container(
-                          padding: const EdgeInsets.all(4),
+                          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
                           decoration: BoxDecoration(
                             color: Colors.black.withValues(alpha: 0.35),
-                            shape: BoxShape.circle,
+                            borderRadius: BorderRadius.circular(16),
                             border: Border.all(
                               color: Colors.white.withValues(alpha: 0.6),
                               width: 0.75,
                             ),
                           ),
-                          child: Icon(
-                            imageHeight >= 380.0
-                                ? Icons.expand_less
-                                : Icons.expand_more,
-                            size: 16,
-                            color: Colors.white.withValues(alpha: 0.9),
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Text(
+                                imageHeight >= 380.0 ? 'Drag to reduce' : 'Drag to enlarge',
+                                style: TextStyle(
+                                  color: Colors.white.withValues(alpha: 0.9),
+                                  fontSize: 11,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                              const SizedBox(width: 6),
+                              Icon(
+                                imageHeight >= 380.0 ? Icons.expand_less : Icons.expand_more,
+                                size: 16,
+                                color: Colors.white.withValues(alpha: 0.9),
+                              ),
+                            ],
                           ),
                         ),
                       ),


### PR DESCRIPTION
Resumo:
- Exibe o texto “Drag to enlarge/reduce” ao lado do ícone de expandir na imagem do Character Details.

Mudanças:
- Substitui o texto fixo por lógica condicional baseada na altura atual da imagem.

Como testar:
- Abrir um Character qualquer → verificar que, no canto inferior direito da imagem, aparece o ícone e o texto.
