### PR TITLE
feat: adicionar flag de página para identificação

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR
 ### Added
 - Sidebar: badge com contagem de Favorites, atualizado em tempo real (não mostra quando 0 e mostra “99+” acima de 99).
 - **Random Page**: página adicionada com botão para randomizar um personagem e exibir seu card.
+- Identificação da página: agora exibida abaixo da AppBar e acima do conteúdo principal em todas as páginas.
 
 ### Removed
 - Filtro de Characters: opção “Outros” em Species (todas as espécies já estão contempladas).

--- a/lib/components/navigation/page_flag.dart
+++ b/lib/components/navigation/page_flag.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:rick_morty_app/theme/app_colors.dart';
+
+class PageFlag extends StatelessWidget {
+  const PageFlag(this.text, {super.key});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text.toUpperCase(),
+      textAlign: TextAlign.left,
+      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+            color: AppColors.white.withValues(alpha: 0.92),
+            fontWeight: FontWeight.w600,
+            fontSize: 16,
+            height: 1.0,
+            letterSpacing: 16 * 0.08,
+          ),
+    );
+  }
+}

--- a/lib/pages/episodes_page.dart
+++ b/lib/pages/episodes_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:rick_morty_app/components/app_bar/app_bar_component.dart';
 import 'package:rick_morty_app/components/cards/episode_card.dart';
 import 'package:rick_morty_app/components/filters/filter_episode_component.dart';
+import 'package:rick_morty_app/components/navigation/page_flag.dart';
 import 'package:rick_morty_app/components/navigation/pagination_bar.dart';
 import 'package:rick_morty_app/components/navigation/search_bar_component.dart';
 import 'package:rick_morty_app/components/navigation/side_bar_component.dart';
@@ -77,6 +78,8 @@ class _EpisodesPageState extends State<EpisodesPage> {
           return ListView(
             padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
             children: [
+              const PageFlag('Episodes'),
+              const SizedBox(height: 16),
               SearchBarComponent(
                 controller: _searchController,
                 hintText: 'Search episode...',

--- a/lib/pages/favorites_page.dart
+++ b/lib/pages/favorites_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:rick_morty_app/components/app_bar/app_bar_component.dart';
 import 'package:rick_morty_app/components/buttons/clear_favorite_button.dart';
 import 'package:rick_morty_app/components/grids/favorite_character_grid.dart';
+import 'package:rick_morty_app/components/navigation/page_flag.dart';
 import 'package:rick_morty_app/components/navigation/side_bar_component.dart';
 import 'package:rick_morty_app/services/favorites_service.dart';
 import 'package:rick_morty_app/theme/app_colors.dart';
@@ -66,9 +67,14 @@ class _FavoritesPageState extends State<FavoritesPage> {
             );
           }
           return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
+              const Padding(
+                padding: EdgeInsets.fromLTRB(16, 16, 16, 0),
+                child: PageFlag('Favorites'),
+              ),
               Padding(
-                padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+                padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
                 child: Align(
                   alignment: Alignment.centerRight,
                   child: const ClearFavoritesButton(),

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:rick_morty_app/components/app_bar/app_bar_component.dart';
 import 'package:rick_morty_app/components/cards/character_card.dart';
 import 'package:rick_morty_app/components/filters/filter_character_component.dart';
+import 'package:rick_morty_app/components/navigation/page_flag.dart';
 import 'package:rick_morty_app/components/navigation/pagination_bar.dart';
 import 'package:rick_morty_app/components/navigation/search_bar_component.dart';
 import 'package:rick_morty_app/components/navigation/side_bar_component.dart';
@@ -106,16 +107,23 @@ class _HomePageState extends State<HomePage> {
                 if (index == 0) {
                   return Padding(
                     padding: const EdgeInsets.symmetric(vertical: 7.5, horizontal: 20),
-                    child: SearchBarComponent(
-                      controller: _searchController,
-                      onSubmitted: _applySearch,
-                      onClear: _clearSearch,
-                      isLoading: isLoading,
-                      trailingFilter: FilterCharacterComponent(
-                        currentFilters: _filters,
-                        onApplyFilters: _applyFilters,
-                      ), 
-                    )
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const PageFlag('Characters'),
+                        const SizedBox(height: 16),
+                        SearchBarComponent(
+                          controller: _searchController,
+                          onSubmitted: _applySearch,
+                          onClear: _clearSearch,
+                          isLoading: isLoading,
+                          trailingFilter: FilterCharacterComponent(
+                            currentFilters: _filters,
+                            onApplyFilters: _applyFilters,
+                          ),
+                        ),
+                      ],
+                    ),
                   );
                 }
 

--- a/lib/pages/locations_page.dart
+++ b/lib/pages/locations_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:rick_morty_app/components/app_bar/app_bar_component.dart';
 import 'package:rick_morty_app/components/cards/location_card.dart';
+import 'package:rick_morty_app/components/navigation/page_flag.dart';
 import 'package:rick_morty_app/components/navigation/pagination_bar.dart';
 import 'package:rick_morty_app/components/navigation/search_bar_component.dart';
 import 'package:rick_morty_app/components/navigation/side_bar_component.dart';
@@ -84,6 +85,8 @@ class _LocationsPageState extends State<LocationsPage> {
           return ListView(
             padding: const EdgeInsets.symmetric(vertical: 15, horizontal: 20),
             children: [
+              const PageFlag('Locations'),
+              const SizedBox(height: 16),
               SearchBarComponent(
                 controller: _searchController,
                 hintText: 'Search location...',

--- a/lib/pages/random_page.dart
+++ b/lib/pages/random_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:rick_morty_app/components/app_bar/app_bar_component.dart';
 import 'package:rick_morty_app/components/cards/character_card.dart';
+import 'package:rick_morty_app/components/navigation/page_flag.dart';
 import 'package:rick_morty_app/components/navigation/side_bar_component.dart';
 import 'package:rick_morty_app/data/repository.dart';
 import 'package:rick_morty_app/models/character.dart';
@@ -45,6 +46,8 @@ class _RandomPageState extends State<RandomPage> {
       body: ListView(
         padding: const EdgeInsets.fromLTRB(18, 16, 18, 0),
         children: [
+          const PageFlag('Random Character'),
+          const SizedBox(height: 16),
           SizedBox(
             height: 48,
             child: ElevatedButton.icon(


### PR DESCRIPTION
Resumo:
- Adiciona flag de página para melhor identificação visual.

Mudanças:
- Cria componente reutilizável PageFlag e adiciona em todas as páginas.

Como testar:
- Abrir qualquer página e verificar se o nome da mesma aparece abaixo da AppBar, na esquerda.
