### PR TITLE
feat: ranking só exibe usuários verificados

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR
 
 - **Profile Page**: nova tela de perfil com exibição dos recordes globais (High Scores).
 
-- **Leaderboard Page**: nova tela de ranking global onde é possível visualizar os Top 20 jogadores por nível de dificuldade.
+- **Leaderboard Page**: nova tela de ranking global onde é possível visualizar os Top 20 jogadores por nível de dificuldade - apenas para usuários verificados.
 
 ## [v1.2.0] - 2025-09-17
 

--- a/lib/components/navigation/side_bar_component.dart
+++ b/lib/components/navigation/side_bar_component.dart
@@ -102,6 +102,13 @@ class SideBarComponent extends StatelessWidget {
                       selected: _isRoute(context, QuizPage.routeId),
                       onTap: () => _goToNamed(context, QuizPage.routeId),
                     ),
+                    ListTile(
+                      leading: const Icon(Icons.emoji_events_outlined),
+                      title: const Text('Leaderboard'),
+                      dense: true,
+                      selected: _isRoute(context, LeaderboardPage.routeId),
+                      onTap: () => _goToNamed(context, LeaderboardPage.routeId),
+                    ),
 
                     const SectionLabel('Pages'),
                     
@@ -144,13 +151,6 @@ class SideBarComponent extends StatelessWidget {
                       dense: true,
                       selected: _isRoute(context, RandomPage.routeId),
                       onTap: () => _goToNamed(context, RandomPage.routeId),
-                    ),
-                    ListTile(
-                      leading: const Icon(Icons.emoji_events_outlined),
-                      title: const Text('Leaderboard'),
-                      dense: true,
-                      selected: _isRoute(context, LeaderboardPage.routeId),
-                      onTap: () => _goToNamed(context, LeaderboardPage.routeId),
                     ),
                   ],
                 ),

--- a/lib/services/leaderboard_service.dart
+++ b/lib/services/leaderboard_service.dart
@@ -36,7 +36,7 @@ class LeaderboardService {
       await _db.collection('users').doc(user.id).update({
         fieldToUpdate: newScore,
       });
-      
+
       await AuthService.instance.init(); 
     }
   }
@@ -58,8 +58,9 @@ class LeaderboardService {
     try {
       final query = await _db
           .collection('users')
+          .where('isVerified', isEqualTo: true)
           .orderBy(orderByField, descending: true)
-          .limit(20) 
+          .limit(20)
           .get();
 
       return query.docs.map((doc) => AppUser.fromMap(doc.data())).toList();


### PR DESCRIPTION
Resumo: 
- Aplica regra para exibir apenas usuários com e-mail verificado no Ranking Global.

Mudanças:
- LeaderboardService: atualização da query `getTopPlayers` para filtrar documentos onde `isVerified` é `true`.

Como testar:
1.  Criar uma conta nova (não verificar o e-mail) → jogar o Quiz para fazer pontos.
2.  Abrir o Leaderboard com outra conta verificada (ou no mesmo dispositivo) →  a conta não verificada não deve aparecer na lista.