### PR TITLE
feat: confirmacao senha no cadastro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR
 
 ## [Unreleased]
 
+### Added
+- **Auth**: adiciona confirmação de senha ao criar nova conta.
+
 ### Fixed
 - **Auth/Sync**: corrige inconsistência de dados no Perfil entre telas de perfil, quiz e leaderboard. Agora as informações sÃo atualizadas e refletidas em todo o app sempre que puxar para recarregar, mesmo se vindas de meio externo (como conta logada em outro dispositivo).
 

--- a/lib/components/auth/auth_form_content.dart
+++ b/lib/components/auth/auth_form_content.dart
@@ -6,7 +6,7 @@ class AuthFormContent extends StatefulWidget {
     super.key,
     required this.isLoading,
     required this.onSubmit,
-    required this.onForgotPassword, 
+    required this.onForgotPassword,
   });
 
   final bool isLoading;
@@ -29,6 +29,7 @@ class _AuthFormContentState extends State<AuthFormContent> with SingleTickerProv
   
   final _emailCtrl = TextEditingController();
   final _passCtrl = TextEditingController();
+  final _passConfirmCtrl = TextEditingController(); 
   final _nickCtrl = TextEditingController();
 
   static final _emailRegex = RegExp(r"^[a-zA-Z0-9.a-zA-Z0-9.!#$%&'*+-/=?^_`{|}~]+@[a-zA-Z0-9]+\.[a-zA-Z]+");
@@ -41,6 +42,7 @@ class _AuthFormContentState extends State<AuthFormContent> with SingleTickerProv
     _tabController.addListener(() {
       if (_tabController.indexIsChanging) {
         _formKey.currentState?.reset();
+        _passConfirmCtrl.clear(); 
       }
     });
   }
@@ -122,6 +124,28 @@ class _AuthFormContentState extends State<AuthFormContent> with SingleTickerProv
             icon: Icons.lock_outline,
             isPass: true,
             validator: (v) => v!.length < 6 ? "Min 6 chars" : null,
+          ),
+
+          AnimatedBuilder(
+            animation: _tabController,
+            builder: (context, _) {
+              return _tabController.index == 1
+                  ? Padding(
+                      padding: const EdgeInsets.only(top: 16),
+                      child: _buildTextField(
+                        controller: _passConfirmCtrl,
+                        label: "Confirm Password",
+                        icon: Icons.lock_reset,
+                        isPass: true,
+                        validator: (v) {
+                          if (v == null || v.isEmpty) return 'Required';
+                          if (v != _passCtrl.text) return 'Passwords do not match';
+                          return null;
+                        },
+                      ),
+                    )
+                  : const SizedBox.shrink();
+            },
           ),
           
           AnimatedBuilder(


### PR DESCRIPTION
Resumo: 
- Adiciona um campo obrigatório de confirmação de senha na hora do cadastro de conta.

Mudanças:
- Adição do TextEditingController para confirmação de senha e inclusão visual do campo "Confirm Password" condicionado à aba de Sign Up.

Como testar:
1. Preencher e-mail e nickname em nova criação de conta.
2. Digitar uma senha.
3. Digitar uma confirmação diferente (ex: 654321) e tentar criar a conta → o campo deve exibir o erro "Passwords do not match".